### PR TITLE
Add Node test setup and agent info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# AGENTS
+
+This repository contains a simple Google Apps Script project with a minimal Node.js testing environment.
+
+## Structure
+- `Code.gs` – Google Apps Script server code.
+- `index.html` – HTML interface for the web app.
+- `weather.js` – Node.js module mirroring the `weatherCodeToText` function for tests.
+- `tests/` – Jest test suite for Node-based tests.
+
+## Testing
+Run `npm test` to execute Jest tests.
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "codex",
+  "version": "1.0.0",
+  "description": "This repository contains a simple Google Apps Script project.",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
+}

--- a/tests/weather.test.js
+++ b/tests/weather.test.js
@@ -1,0 +1,7 @@
+const { weatherCodeToText } = require('../weather');
+
+test('returns correct mapping', () => {
+  expect(weatherCodeToText(0)).toBe('Clear sky');
+  expect(weatherCodeToText(95)).toBe('Thunderstorm');
+  expect(weatherCodeToText(999)).toBe('Unknown');
+});

--- a/weather.js
+++ b/weather.js
@@ -1,0 +1,35 @@
+function weatherCodeToText(code) {
+  const mapping = {
+    0: 'Clear sky',
+    1: 'Mainly clear',
+    2: 'Partly cloudy',
+    3: 'Overcast',
+    45: 'Fog',
+    48: 'Depositing rime fog',
+    51: 'Light drizzle',
+    53: 'Moderate drizzle',
+    55: 'Dense drizzle',
+    56: 'Light freezing drizzle',
+    57: 'Dense freezing drizzle',
+    61: 'Slight rain',
+    63: 'Moderate rain',
+    65: 'Heavy rain',
+    66: 'Light freezing rain',
+    67: 'Heavy freezing rain',
+    71: 'Slight snow fall',
+    73: 'Moderate snow fall',
+    75: 'Heavy snow fall',
+    77: 'Snow grains',
+    80: 'Slight rain showers',
+    81: 'Moderate rain showers',
+    82: 'Violent rain showers',
+    85: 'Slight snow showers',
+    86: 'Heavy snow showers',
+    95: 'Thunderstorm',
+    96: 'Thunderstorm with slight hail',
+    99: 'Thunderstorm with heavy hail'
+  };
+  return mapping[code] || 'Unknown';
+}
+
+module.exports = { weatherCodeToText };


### PR DESCRIPTION
## Summary
- add AGENTS instructions
- configure jest for tests and provide minimal weather module
- add basic weather mapping test
- ignore node_modules and lockfile

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68451c14fa60832290215606701d6981