### PR TITLE
Increase fire visuals

### DIFF
--- a/index.html
+++ b/index.html
@@ -181,6 +181,9 @@
       .fire:nth-child(1) { animation-delay: 0s; }
       .fire:nth-child(2) { animation-delay: 1s; }
       .fire:nth-child(3) { animation-delay: 2s; }
+      .fire:nth-child(4) { animation-delay: 3s; }
+      .fire:nth-child(5) { animation-delay: 4s; }
+      .fire:nth-child(6) { animation-delay: 5s; }
 
       @keyframes flicker { from { background-position: 0 0; } to { background-position: -1920px 0; } }
       @keyframes descend {
@@ -486,6 +489,9 @@
       <img id="driver-img" src="https://www.dublincleaners.com/wp-content/uploads/2025/06/Driver7.png" alt="Driver">
     </div>
     <div id="weekly-quote" class="weekly-quote"></div>
+    <div class="fire"></div>
+    <div class="fire"></div>
+    <div class="fire"></div>
     <div class="fire"></div>
     <div class="fire"></div>
     <div class="fire"></div>


### PR DESCRIPTION
## Summary
- increase the number of fire animation elements to six
- stagger extra flames with additional CSS animation delays

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845437fabcc83229b35c557945e70ce