### PR TITLE
Center align driver overlays

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,27 +156,30 @@
       .weekly-quote {
         position: fixed;
         bottom: 10px;
-        right: 10px;
+        left: 10px;
         color: #ffffff;
         background: rgba(0, 0, 0, 0.5);
         padding: 8px 12px;
         font-style: italic;
         font-size: 14px;
         border-radius: 4px;
+        text-align: center;
       }
       .driver-overlay {
         position: fixed;
         bottom: 160px;
-        right: 10px;
+        left: 10px;
         width: 275px;
         pointer-events: none;
         z-index: 1000;
+        display: flex;
+        justify-content: center;
       }
 
       .driver-week {
         position: fixed;
         bottom: 60px;
-        right: 10px;
+        left: 10px;
         color: #ffffff;
         background: rgba(0, 0, 0, 0.5);
         padding: 8px 12px;
@@ -184,6 +187,10 @@
         z-index: 1000;
         pointer-events: auto;
         width: 300px;
+        text-align: center;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
       }
 
       .driver-week input {
@@ -196,6 +203,7 @@
 
       .driver-week label {
         font-size: 32px;
+        display: block;
       }
       .driver-overlay img {
         width: 100%;


### PR DESCRIPTION
## Summary
- position bottom widgets on left side of the viewport
- center their contents so the image, title, input and quote line up

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846061dcfe48322876c2d6d85137b7d