### PR TITLE
Fix driver image alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -173,7 +173,7 @@
         right: 0;
         height: 300px;
         display: flex;
-        align-items: center;
+        align-items: flex-end;
         overflow: hidden;
         pointer-events: none;
         z-index: 500;
@@ -225,6 +225,7 @@
         width: 225px;
         height: 225px;
         object-fit: cover;
+        object-position: bottom;
       }
       #loading-overlay {
         position: fixed;


### PR DESCRIPTION
## Summary
- keep driver carousel images pinned to bottom

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687a7342ca1c8322973ed90aea4ecee4