### PR TITLE
Remove old driver images on new upload

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -184,3 +184,17 @@ function addDriverImage(data) {
   arr.push(file.getId());
   props.setProperty('driverImageIds', JSON.stringify(arr));
 }
+
+function clearDriverImages() {
+  var props = PropertiesService.getScriptProperties();
+  var ids = props.getProperty('driverImageIds');
+  if (!ids) return;
+  JSON.parse(ids).forEach(function(id) {
+    try {
+      DriveApp.getFileById(id).setTrashed(true);
+    } catch (e) {
+      // ignore missing file
+    }
+  });
+  props.deleteProperty('driverImageIds');
+}

--- a/index.html
+++ b/index.html
@@ -307,17 +307,23 @@
         });
         driverInput.addEventListener('change', function() {
           var files = Array.from(this.files || []);
-          files.forEach(function(file) {
-            var reader = new FileReader();
-            reader.onload = function(e) {
-              var src = e.target.result;
-              driverImages.push(src);
-              google.script.run.addDriverImage(src);
-              startCarousel();
-            };
-            reader.readAsDataURL(file);
-          });
-          this.value = '';
+          var input = this;
+          if (files.length === 0) return;
+          google.script.run.withSuccessHandler(function() {
+            driverImages = [];
+            var remaining = files.length;
+            files.forEach(function(file) {
+              var reader = new FileReader();
+              reader.onload = function(e) {
+                var src = e.target.result;
+                driverImages.push(src);
+                google.script.run.addDriverImage(src);
+                if (--remaining === 0) startCarousel();
+              };
+              reader.readAsDataURL(file);
+            });
+            input.value = '';
+          }).clearDriverImages();
         });
         google.script.run.withSuccessHandler(function(src) {
           if (src) document.querySelector('.logo img').src = src;


### PR DESCRIPTION
## Summary
- add `clearDriverImages` to remove existing images before storing new ones
- call `clearDriverImages` from the driver image upload handler

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a75664fc4832285967052ad7d9d3a