### PR TITLE
Persist driver images between refreshes

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -198,3 +198,24 @@ function clearDriverImages() {
   });
   props.deleteProperty('driverImageIds');
 }
+
+function updateDriverImages(list) {
+  // Replace existing driver images with a new set provided as base64 data URLs
+  clearDriverImages();
+  if (!list || !list.length) return [];
+  var ids = [];
+  list.forEach(function(data) {
+    var m = data.match(/^data:(.+);base64,(.+)$/);
+    if (!m) return;
+    var contentType = m[1];
+    var bytes = Utilities.base64Decode(m[2]);
+    var blob = Utilities.newBlob(bytes, contentType, 'driver-image');
+    var file = DriveApp.createFile(blob);
+    ids.push(file.getId());
+  });
+  PropertiesService.getScriptProperties().setProperty(
+    'driverImageIds',
+    JSON.stringify(ids)
+  );
+  return getDriverImages();
+}

--- a/index.html
+++ b/index.html
@@ -310,21 +310,24 @@
           var files = Array.from(this.files || []);
           var input = this;
           if (files.length === 0) return;
-          google.script.run.withSuccessHandler(function() {
-            driverImages = [];
-            var remaining = files.length;
-            files.forEach(function(file) {
-              var reader = new FileReader();
-              reader.onload = function(e) {
-                var src = e.target.result;
-                driverImages.push(src);
-                google.script.run.addDriverImage(src);
-                if (--remaining === 0) startCarousel();
-              };
-              reader.readAsDataURL(file);
-            });
-            input.value = '';
-          }).clearDriverImages();
+          var data = [];
+          var remaining = files.length;
+          files.forEach(function(file) {
+            var reader = new FileReader();
+            reader.onload = function(e) {
+              data.push(e.target.result);
+              if (--remaining === 0) {
+                google.script.run
+                  .withSuccessHandler(function(list) {
+                    driverImages = list || data;
+                    startCarousel();
+                    input.value = '';
+                  })
+                  .updateDriverImages(data);
+              }
+            };
+            reader.readAsDataURL(file);
+          });
         });
         google.script.run.withSuccessHandler(function(src) {
           if (src) document.querySelector('.logo img').src = src;


### PR DESCRIPTION
## Summary
- maintain driver carousel after page reloads
- store new images on the server in one call

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a7fa3f8348322a3b547ade6f84780