### PR TITLE
Handle quote API failures without caching fallback

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -92,10 +92,13 @@ function getRandomQuote() {
       props.setProperty('weeklyQuote', newQuote);
       props.setProperty('weeklyQuoteDate', now.toISOString());
       quote = newQuote;
+    } else {
+      // fetch failed; use a random fallback without updating the timestamp
+      quote = FALLBACK_QUOTES[Math.floor(Math.random() * FALLBACK_QUOTES.length)];
     }
   }
 
-  return quote || 'Quote unavailable';
+  return quote || FALLBACK_QUOTES[Math.floor(Math.random() * FALLBACK_QUOTES.length)];
 }
 
 var FALLBACK_QUOTES = [
@@ -116,8 +119,8 @@ function fetchQuote() {
   } catch (e) {
     // ignore errors and fall through
   }
-  // Use a random local quote as a fallback
-  return FALLBACK_QUOTES[Math.floor(Math.random() * FALLBACK_QUOTES.length)];
+  // return null to indicate failure so caller can decide how to handle
+  return null;
 }
 
 function getHeaderTitle() {


### PR DESCRIPTION
## Summary
- Avoid caching fallback quotes when the external quote API fails
- Return `null` on fetch failure and use a temporary fallback instead

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d5c7b0de08322b32b4b9edb10f27f