### PR TITLE
Display date and time on one line

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,10 @@
       }
       .datetime .date,
       .datetime .time {
-        display: block;
+        display: inline-block;
+      }
+      .datetime .date {
+        margin-right: 8px;
       }
       .weather {
         text-align: center;
@@ -273,7 +276,7 @@
         function updateDateTime() {
           var now = new Date();
           document.getElementById('datetime').innerHTML =
-            '<span class="date">' + now.toLocaleDateString() + '</span>' +
+            '<span class="date">' + now.toLocaleDateString() + '</span> ' +
             '<span class="time">' + now.toLocaleTimeString() + '</span>';
         }
 


### PR DESCRIPTION
## Summary
- Show date and time side-by-side by rendering their spans inline with spacing.
- Update `updateDateTime` to insert a space between date and time values.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68922ba55778832298da0a8dc7c62aa0