### PR TITLE
Remove temp label from weather display

### DIFF
--- a/index.html
+++ b/index.html
@@ -296,7 +296,7 @@
           var condEl = document.getElementById('weather-condition');
           if (data) {
             iconEl.textContent = getWeatherIcon(data.condition);
-            tempEl.textContent = 'Temp: ' + data.temperature + '°F';
+            tempEl.textContent = data.temperature + '°F';
             condEl.textContent = data.condition;
           } else {
             iconEl.textContent = '';


### PR DESCRIPTION
## Summary
- Remove "Temp:" prefix from weather display

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892308a1d4c8322871431124b953c37