### PR TITLE
Respect lock state on resize

### DIFF
--- a/index.html
+++ b/index.html
@@ -393,6 +393,7 @@
         btn.addEventListener('click', function() {
           framesLocked = !framesLocked;
           btn.textContent = framesLocked ? 'Unlock' : 'Lock';
+          if (!framesLocked) keepFramesInView();
         });
         btn.textContent = 'Unlock';
       }
@@ -873,7 +874,7 @@
       }
 
       function keepFramesInView() {
-        if (!framesLoaded) return;
+        if (!framesLoaded || framesLocked) return;
         var area = document.getElementById('viewing-area');
         var rect = area.getBoundingClientRect();
         var children = document.querySelectorAll('.viewing-area .frame');


### PR DESCRIPTION
## Summary
- Keep frame positions unchanged while locked, even after window resizes
- Re-evaluate frame bounds only when unlocked

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5d2c1ee808322af224547697bbbdd