### PR TITLE
Enable scrolling on reduced viewports

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
           display: flex;
           flex-direction: column;
           min-height: 100vh;
-          overflow: hidden;
+          overflow: auto;
           cursor: auto;
         }
       .header {
@@ -101,7 +101,7 @@
       .viewing-area {
         position: relative;
         flex: 1;
-        overflow: hidden;
+        overflow: auto;
         background-color: transparent;
       }
       .frame {


### PR DESCRIPTION
## Summary
- Allow vertical and horizontal scrolling when the dashboard page is resized by switching `body` and `viewing-area` to use automatic overflow.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5d3e14e3c8322b0014cadb8aa6007