### PR TITLE
Add dashboard visibility and sheet layout controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,6 +111,9 @@
         box-sizing: border-box;
         cursor: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCI+PGxpbmUgeDE9IjEyIiB5MT0iMCIgeDI9IjEyIiB5Mj0iMjQiIHN0cm9rZT0iI2IzMDAwMCIgc3Ryb2tlLXdpZHRoPSIyIi8+PGxpbmUgeDE9IjAiIHkxPSIxMiIgeDI9IjI0IiB5Mj0iMTIiIHN0cm9rZT0iI2IzMDAwMCIgc3Ryb2tlLXdpZHRoPSIyIi8+PGNpcmNsZSBjeD0iMTIiIGN5PSIxMiIgcj0iMTEiIHN0cm9rZT0iYmxhY2siIGZpbGw9Im5vbmUiIHN0cm9rZS13aWR0aD0iMiIvPjwvc3ZnPg==') 12 12, crosshair;
         font-size: 133%;
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
       }
       .frame-header {
         background: #333;
@@ -160,6 +163,9 @@
       .spreadsheet {
         cursor: text;
         overflow: auto;
+        flex: 1 1 50%;
+        background: #fff;
+        min-height: 120px;
       }
       .spreadsheet table {
         border-collapse: collapse;
@@ -271,7 +277,130 @@
         height: 120px;
       }
 
+      .dashboard {
+        flex: 1 1 45%;
+        min-height: 160px;
+        border-top: 1px solid #e6e6e6;
+        padding: 8px 10px 12px;
+        background: #fafafa;
+        color: #2d2d2d;
+        overflow: auto;
+      }
+
+      .dashboard-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: 6px;
+        gap: 8px;
+        font-weight: bold;
+        font-size: 14px;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        color: #333;
+      }
+
+      .dashboard-header-left {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+      }
+
+      .dashboard-header button {
+        font-size: 11px;
+        padding: 4px 8px;
+        border: 1px solid #c7c7c7;
+        background: #fff;
+        color: #333;
+        cursor: pointer;
+        text-transform: none;
+        font-weight: 600;
+        letter-spacing: normal;
+      }
+
+      .dashboard-header button:hover {
+        background: #f2f2f2;
+      }
+
+      .dashboard-header select {
+        font-size: 12px;
+        padding: 3px 6px;
+      }
+
+      .dashboard-form {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+        margin-bottom: 8px;
+        align-items: flex-end;
+      }
+
+      .dashboard-form label {
+        font-size: 11px;
+        font-weight: 600;
+        color: #555;
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+      }
+
+      .dashboard-form input,
+      .dashboard-form select {
+        padding: 4px 6px;
+        font-size: 12px;
+      }
+
+      .dashboard-empty {
+        font-size: 12px;
+        color: #666;
+        font-style: italic;
+      }
+
+      .dashboard-list table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 12px;
+      }
+
+      .dashboard-list th,
+      .dashboard-list td {
+        border-bottom: 1px solid #ddd;
+        padding: 4px 2px;
+        text-align: left;
+      }
+
+      .dashboard-list td.value {
+        text-align: right;
+        font-weight: 600;
+      }
+
+      .dashboard-chart {
+        position: relative;
+        height: 190px;
+        margin-top: 10px;
+      }
+
+      .dashboard-chart canvas {
+        width: 100% !important;
+        height: 100% !important;
+      }
+
+      .dashboard-hidden {
+        flex: 0 0 auto;
+      }
+
+      .dashboard-hidden .dashboard-header {
+        margin-bottom: 4px;
+      }
+
+      .dashboard-hidden-message {
+        font-size: 12px;
+        color: #777;
+        font-style: italic;
+      }
+
     </style>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
     <script>
         function updateDateTime() {
           var now = new Date();
@@ -426,6 +555,507 @@
       var driverImages = [];
       var pendingLoads = 0;
       var loadingInterval = null;
+      var chartInstances = {};
+      var frameIdCounter = 0;
+
+      function generateFrameId() {
+        frameIdCounter += 1;
+        return 'frame-' + Date.now().toString(36) + '-' + frameIdCounter.toString(36);
+      }
+
+      function createDefaultDashboard() {
+        return {
+          chartType: 'line',
+          labelColumn: 0,
+          valueColumn: 1,
+          visible: true,
+          sheetSize: 'balanced'
+        };
+      }
+
+      function ensureFrameMetadata(frame) {
+        var updated = false;
+        if (!frame.id) {
+          frame.id = generateFrameId();
+          updated = true;
+        }
+        if (!frame.dashboard || typeof frame.dashboard !== 'object') {
+          frame.dashboard = createDefaultDashboard();
+          updated = true;
+        }
+        var allowedCharts = ['line', 'bar', 'pie'];
+        if (allowedCharts.indexOf(frame.dashboard.chartType) === -1) {
+          frame.dashboard.chartType = 'line';
+          updated = true;
+        }
+        if (typeof frame.dashboard.labelColumn !== 'number' || isNaN(frame.dashboard.labelColumn)) {
+          frame.dashboard.labelColumn = 0;
+          updated = true;
+        }
+        if (typeof frame.dashboard.valueColumn !== 'number' || isNaN(frame.dashboard.valueColumn)) {
+          frame.dashboard.valueColumn = 1;
+          updated = true;
+        }
+        if (typeof frame.dashboard.visible !== 'boolean') {
+          frame.dashboard.visible = true;
+          updated = true;
+        }
+        var allowedSizes = ['compact', 'balanced', 'expanded'];
+        if (allowedSizes.indexOf(frame.dashboard.sheetSize) === -1) {
+          frame.dashboard.sheetSize = 'balanced';
+          updated = true;
+        }
+        if (frame.dashboard.hasOwnProperty('data')) {
+          delete frame.dashboard.data;
+          updated = true;
+        }
+        return updated;
+      }
+
+      function applyFrameLayout(frameElement, frame) {
+        if (!frameElement || !frame) return;
+        var sheetEl = frameElement.querySelector('.spreadsheet');
+        var dashEl = frameElement.querySelector('.dashboard');
+        if (!sheetEl || !dashEl) return;
+        var dashboard = frame.dashboard || {};
+        var size = dashboard.sheetSize || 'balanced';
+        var sizes = {
+          compact: { sheet: '0.8 1 35%', dashboard: '1 1 55%' },
+          balanced: { sheet: '1 1 50%', dashboard: '1 1 45%' },
+          expanded: { sheet: '1.4 1 65%', dashboard: '1 1 35%' }
+        };
+        var selected = sizes[size] || sizes.balanced;
+        if (dashboard.visible === false) {
+          sheetEl.style.display = '';
+          sheetEl.style.flex = '1 1 100%';
+          dashEl.style.flex = '0 0 auto';
+          return;
+        }
+        sheetEl.style.display = '';
+        sheetEl.style.flex = selected.sheet;
+        dashEl.style.flex = selected.dashboard;
+      }
+
+      function formatDateLabel(dateStr) {
+        if (!dateStr) return '';
+        var date = new Date(dateStr);
+        if (isNaN(date.getTime())) return dateStr;
+        return date.toLocaleDateString();
+      }
+
+      function columnNameFromIndex(index) {
+        if (index < 0) return '';
+        var name = '';
+        var current = index;
+        do {
+          name = String.fromCharCode((current % 26) + 65) + name;
+          current = Math.floor(current / 26) - 1;
+        } while (current >= 0);
+        return name;
+      }
+
+      function getColumnHeader(sheet, index) {
+        if (!sheet || !sheet.data || !sheet.data.length) return '';
+        var firstRow = sheet.data[0] || [];
+        if (index < 0 || index >= firstRow.length) return '';
+        var raw = firstRow[index];
+        return raw == null ? '' : String(raw).trim();
+      }
+
+      function ensureDashboardColumnBounds(frame) {
+        if (!frame || !frame.sheet || typeof frame.sheet.cols !== 'number') return false;
+        var dashboard = frame.dashboard || {};
+        var maxIndex = Math.max(0, frame.sheet.cols - 1);
+        var updated = false;
+        var label = typeof dashboard.labelColumn === 'number' ? dashboard.labelColumn : 0;
+        var value = typeof dashboard.valueColumn === 'number' ? dashboard.valueColumn : 1;
+        if (label < 0) {
+          label = 0;
+          updated = true;
+        }
+        if (label > maxIndex) {
+          label = maxIndex;
+          updated = true;
+        }
+        if (value < 0) {
+          value = 0;
+          updated = true;
+        }
+        if (value > maxIndex) {
+          value = maxIndex;
+          updated = true;
+        }
+        if (dashboard.labelColumn !== label) {
+          dashboard.labelColumn = label;
+          updated = true;
+        }
+        if (dashboard.valueColumn !== value) {
+          dashboard.valueColumn = value;
+          updated = true;
+        }
+        return updated;
+      }
+
+      function extractDashboardData(frame) {
+        if (!frame || !frame.sheet) return [];
+        var sheet = frame.sheet;
+        evaluateSheet(sheet);
+        ensureDashboardColumnBounds(frame);
+        var labelIndex = frame.dashboard.labelColumn;
+        var valueIndex = frame.dashboard.valueColumn;
+        var entries = [];
+        for (var r = 1; r < sheet.rows; r++) {
+          var rowComputed = sheet.computed[r] || [];
+          var rowRaw = sheet.data[r] || [];
+          var labelValue = rowComputed[labelIndex];
+          if (labelValue == null || labelValue === '') {
+            labelValue = rowRaw[labelIndex];
+          }
+          var label = labelValue == null ? '' : String(labelValue).trim();
+          var valueRaw = rowComputed[valueIndex];
+          if (valueRaw == null || valueRaw === '') valueRaw = rowRaw[valueIndex];
+          var numeric = typeof valueRaw === 'number' ? valueRaw : parseFloat(valueRaw);
+          if (isNaN(numeric)) continue;
+          var entry = {
+            label: label,
+            value: numeric,
+            row: r
+          };
+          var potentialDate = label || rowRaw[labelIndex];
+          if (potentialDate && !isNaN(Date.parse(potentialDate))) {
+            entry.date = potentialDate;
+          }
+          entries.push(entry);
+        }
+        return entries;
+      }
+
+      function getEntryAxisLabel(entry, idx) {
+        if (entry.label && entry.label.trim()) return entry.label.trim();
+        var formatted = formatDateLabel(entry.date);
+        if (formatted) return formatted;
+        if (typeof entry.row === 'number') return 'Row ' + (entry.row + 1);
+        return 'Entry ' + (idx + 1);
+      }
+
+      function getEntrySummary(entry, idx) {
+        var formatted = formatDateLabel(entry.date);
+        if (entry.label && formatted) return formatted + ' — ' + entry.label;
+        if (entry.label) return entry.label;
+        if (formatted) return formatted;
+        if (typeof entry.row === 'number') return 'Row ' + (entry.row + 1);
+        return 'Entry ' + (idx + 1);
+      }
+
+      function buildColorPalette(count) {
+        var base = [
+          '#b30000',
+          '#ff6f61',
+          '#ffd166',
+          '#06d6a0',
+          '#118ab2',
+          '#073b4c',
+          '#8338ec',
+          '#ef476f'
+        ];
+        var palette = [];
+        for (var i = 0; i < count; i++) {
+          palette.push(base[i % base.length]);
+        }
+        return palette;
+      }
+
+      function buildChartConfig(frame, data) {
+        var type = frame.dashboard.chartType || 'line';
+        var labels = data.map(function(entry, idx) {
+          return getEntryAxisLabel(entry, idx);
+        });
+        var values = data.map(function(entry) {
+          return entry.value;
+        });
+        var datasetLabel = getColumnHeader(frame.sheet, frame.dashboard.valueColumn);
+        if (!datasetLabel) {
+          datasetLabel = frame.title || 'Data';
+        }
+        if (type === 'pie') {
+          return {
+            type: 'pie',
+            data: {
+              labels: labels,
+              datasets: [
+                {
+                  data: values,
+                  backgroundColor: buildColorPalette(values.length),
+                  borderColor: '#ffffff',
+                  borderWidth: 1
+                }
+              ]
+            },
+            options: {
+              responsive: true,
+              maintainAspectRatio: false,
+              plugins: {
+                legend: {
+                  position: 'bottom',
+                  labels: { boxWidth: 12, boxHeight: 12 }
+                }
+              }
+            }
+          };
+        }
+        var isLine = type === 'line';
+        return {
+          type: type,
+          data: {
+            labels: labels,
+            datasets: [
+              {
+                label: datasetLabel,
+                data: values,
+                borderColor: '#b30000',
+                backgroundColor: isLine ? 'rgba(179, 0, 0, 0.18)' : '#ff6f61',
+                tension: isLine ? 0.35 : 0,
+                fill: isLine,
+                pointRadius: isLine ? 3 : 0,
+                pointBackgroundColor: '#b30000',
+                borderWidth: 2
+              }
+            ]
+          },
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            scales: {
+              y: {
+                beginAtZero: true,
+                ticks: { precision: 0 }
+              },
+              x: {
+                ticks: { autoSkip: true, maxRotation: 0 }
+              }
+            },
+            plugins: {
+              legend: { display: true, position: 'bottom' },
+              tooltip: {
+                mode: 'index',
+                intersect: false
+              }
+            }
+          }
+        };
+      }
+
+      function destroyDashboard(frameId) {
+        if (chartInstances[frameId]) {
+          chartInstances[frameId].destroy();
+          delete chartInstances[frameId];
+        }
+      }
+
+      function updateDashboardChart(frame, data, canvas) {
+        if (!canvas || typeof Chart === 'undefined') return;
+        destroyDashboard(frame.id);
+        if (!data.length) {
+          return;
+        }
+        chartInstances[frame.id] = new Chart(canvas.getContext('2d'), buildChartConfig(frame, data));
+      }
+
+      function refreshDashboard(index) {
+        var frameDiv = document.querySelector('.frame[data-index="' + index + '"] .dashboard');
+        if (frameDiv) {
+          renderDashboard(frameDiv, index);
+        }
+      }
+
+      function renderDashboard(container, index) {
+        var frame = frames[index];
+        if (!frame) return;
+        ensureFrameMetadata(frame);
+        var dashboard = frame.dashboard;
+        container.innerHTML = '';
+
+        var header = document.createElement('div');
+        header.className = 'dashboard-header';
+        var headerLeft = document.createElement('div');
+        headerLeft.className = 'dashboard-header-left';
+        var title = document.createElement('span');
+        title.textContent = 'Dashboard';
+        headerLeft.appendChild(title);
+
+        var toggleBtn = document.createElement('button');
+        toggleBtn.type = 'button';
+        toggleBtn.textContent = dashboard.visible === false ? 'Show Dashboard' : 'Hide Dashboard';
+        toggleBtn.addEventListener('click', function(e) {
+          e.stopPropagation();
+          dashboard.visible = !dashboard.visible;
+          if (dashboard.visible === false) {
+            destroyDashboard(frame.id);
+          }
+          applyFrameLayout(container.closest('.frame'), frame);
+          if (framesLoaded) saveFrames();
+          renderDashboard(container, index);
+        });
+        headerLeft.appendChild(toggleBtn);
+        header.appendChild(headerLeft);
+
+        container.classList.toggle('dashboard-hidden', dashboard.visible === false);
+
+        if (dashboard.visible !== false) {
+          var typeLabel = document.createElement('label');
+          typeLabel.textContent = 'Chart';
+          var select = document.createElement('select');
+          select.innerHTML = '';
+          ['line', 'bar', 'pie'].forEach(function(option) {
+            var opt = document.createElement('option');
+            opt.value = option;
+            opt.textContent = option.charAt(0).toUpperCase() + option.slice(1);
+            select.appendChild(opt);
+          });
+          select.value = dashboard.chartType || 'line';
+          select.addEventListener('change', function() {
+            dashboard.chartType = select.value;
+            saveFrames();
+            renderDashboard(container, index);
+          });
+          typeLabel.appendChild(select);
+          header.appendChild(typeLabel);
+        }
+        container.appendChild(header);
+
+        if (dashboard.visible === false) {
+          var hiddenMessage = document.createElement('div');
+          hiddenMessage.className = 'dashboard-hidden-message';
+          hiddenMessage.textContent = 'Dashboard hidden. Use "Show Dashboard" to display charts for this frame.';
+          container.appendChild(hiddenMessage);
+          applyFrameLayout(container.closest('.frame'), frame);
+          return;
+        }
+
+        var sheet = frame.sheet;
+        var boundsChanged = ensureDashboardColumnBounds(frame);
+        if (boundsChanged && framesLoaded) saveFrames();
+
+        var form = document.createElement('div');
+        form.className = 'dashboard-form';
+
+        var sizeField = document.createElement('label');
+        sizeField.textContent = 'Sheet size';
+        var sizeSelect = document.createElement('select');
+        [
+          { value: 'compact', label: 'Compact' },
+          { value: 'balanced', label: 'Balanced' },
+          { value: 'expanded', label: 'Expanded' }
+        ].forEach(function(option) {
+          var opt = document.createElement('option');
+          opt.value = option.value;
+          opt.textContent = option.label;
+          sizeSelect.appendChild(opt);
+        });
+        sizeSelect.value = dashboard.sheetSize || 'balanced';
+        sizeSelect.addEventListener('change', function() {
+          dashboard.sheetSize = sizeSelect.value;
+          applyFrameLayout(container.closest('.frame'), frame);
+          if (framesLoaded) saveFrames();
+        });
+        sizeField.appendChild(sizeSelect);
+
+        var labelField = document.createElement('label');
+        labelField.textContent = 'Label column';
+        var labelSelect = document.createElement('select');
+        for (var c = 0; sheet && c < sheet.cols; c++) {
+          var labelOption = document.createElement('option');
+          labelOption.value = c;
+          var headerText = getColumnHeader(sheet, c);
+          var prefix = columnNameFromIndex(c);
+          labelOption.textContent = headerText ? prefix + ' — ' + headerText : prefix;
+          labelSelect.appendChild(labelOption);
+        }
+        labelSelect.value = frame.dashboard.labelColumn;
+        labelSelect.addEventListener('change', function() {
+          frame.dashboard.labelColumn = parseInt(labelSelect.value, 10);
+          if (framesLoaded) saveFrames();
+          renderDashboard(container, index);
+        });
+        labelField.appendChild(labelSelect);
+
+        var valueField = document.createElement('label');
+        valueField.textContent = 'Value column';
+        var valueSelect = document.createElement('select');
+        for (var vc = 0; sheet && vc < sheet.cols; vc++) {
+          var valueOption = document.createElement('option');
+          valueOption.value = vc;
+          var headerValue = getColumnHeader(sheet, vc);
+          var valuePrefix = columnNameFromIndex(vc);
+          valueOption.textContent = headerValue ? valuePrefix + ' — ' + headerValue : valuePrefix;
+          valueSelect.appendChild(valueOption);
+        }
+        valueSelect.value = frame.dashboard.valueColumn;
+        valueSelect.addEventListener('change', function() {
+          frame.dashboard.valueColumn = parseInt(valueSelect.value, 10);
+          if (framesLoaded) saveFrames();
+          renderDashboard(container, index);
+        });
+        valueField.appendChild(valueSelect);
+
+        form.appendChild(sizeField);
+        form.appendChild(labelField);
+        form.appendChild(valueField);
+        container.appendChild(form);
+
+        var dataWrapper = document.createElement('div');
+        dataWrapper.className = 'dashboard-list';
+        var entries = extractDashboardData(frame);
+        if (entries.length === 0) {
+          destroyDashboard(frame.id);
+          var empty = document.createElement('div');
+          empty.className = 'dashboard-empty';
+          empty.textContent = 'Enter labels and numbers in the selected sheet columns to populate this chart automatically.';
+          dataWrapper.appendChild(empty);
+        } else {
+          var table = document.createElement('table');
+          var thead = document.createElement('thead');
+          var headRow = document.createElement('tr');
+          ['Label', 'Value'].forEach(function(text) {
+            var th = document.createElement('th');
+            th.textContent = text;
+            headRow.appendChild(th);
+          });
+          thead.appendChild(headRow);
+          table.appendChild(thead);
+          var tbody = document.createElement('tbody');
+          entries.forEach(function(entry, idx) {
+            var row = document.createElement('tr');
+            var labelCell = document.createElement('td');
+            labelCell.textContent = getEntrySummary(entry, idx);
+            row.appendChild(labelCell);
+            var valueCell = document.createElement('td');
+            valueCell.className = 'value';
+            valueCell.textContent = entry.value.toLocaleString(undefined, { maximumFractionDigits: 2 });
+            row.appendChild(valueCell);
+            tbody.appendChild(row);
+          });
+          table.appendChild(tbody);
+          dataWrapper.appendChild(table);
+        }
+        container.appendChild(dataWrapper);
+
+        var chartContainer = document.createElement('div');
+        chartContainer.className = 'dashboard-chart';
+        var canvas = document.createElement('canvas');
+        chartContainer.appendChild(canvas);
+        container.appendChild(chartContainer);
+
+        if (entries.length === 0) {
+          canvas.style.display = 'none';
+          destroyDashboard(frame.id);
+        } else {
+          canvas.style.display = 'block';
+          updateDashboardChart(frame, entries, canvas);
+        }
+
+        applyFrameLayout(container.closest('.frame'), frame);
+      }
 
       function incrementLoad() {
         pendingLoads++;
@@ -488,9 +1118,16 @@
 
       function loadFrames(data) {
         frames = data || [];
-        frames.forEach(function(f, i) { createFrame(f, i); });
+        var metadataUpdated = false;
+        frames.forEach(function(frame) {
+          if (ensureFrameMetadata(frame)) metadataUpdated = true;
+        });
+        frames.forEach(function(f, i) {
+          createFrame(f, i);
+        });
         framesLoaded = true;
         keepFramesInView();
+        if (metadataUpdated) saveFrames();
       }
 
       function initDriver() {
@@ -516,12 +1153,14 @@
       }
       function addFrame() {
         var frame = {
+          id: generateFrameId(),
           x: 10,
           y: 10,
-          width: 200,
-          height: 150,
+          width: 320,
+          height: 360,
           title: 'Frame',
-          sheet: createDefaultSheet(3, 3)
+          sheet: createDefaultSheet(3, 3),
+          dashboard: createDefaultDashboard()
         };
         frames.push(frame);
         createFrame(frame, frames.length - 1);
@@ -531,6 +1170,7 @@
 
 
       function createFrame(frame, index) {
+        ensureFrameMetadata(frame);
         var area = document.getElementById('viewing-area');
         var div = document.createElement('div');
         div.className = 'frame';
@@ -539,6 +1179,7 @@
         div.style.width = frame.width + 'px';
         div.style.height = frame.height + 'px';
         div.dataset.index = index;
+        div.dataset.frameId = frame.id;
         div.style.zIndex = zIndex++;
 
         var header = document.createElement('div');
@@ -575,22 +1216,41 @@
 
         var sheetDiv = document.createElement('div');
         sheetDiv.className = 'spreadsheet';
-        div.appendChild(sheetDiv);
+
+        var dashboardDiv = document.createElement('div');
+        dashboardDiv.className = 'dashboard';
+
         div.appendChild(btnWrap);
+        div.appendChild(sheetDiv);
+        div.appendChild(dashboardDiv);
 
         var resizer = document.createElement('div');
         resizer.className = 'resizer';
         div.appendChild(resizer);
 
         title.addEventListener('input', function() {
-          frames[parseInt(div.dataset.index, 10)].title = title.textContent;
+          var idx = parseInt(div.dataset.index, 10);
+          frames[idx].title = title.textContent;
           saveFrames();
+          var chart = chartInstances[frames[idx].id];
+          if (chart) {
+            chart.data.datasets.forEach(function(ds) {
+              ds.label = frames[idx].title || 'Data';
+            });
+            chart.update();
+          }
         });
 
         close.addEventListener('click', function(e) {
           e.stopPropagation();
           var idx = parseInt(div.dataset.index, 10);
-          frames.splice(idx, 1);
+          var meta = frames[idx];
+          if (meta) {
+            destroyDashboard(meta.id);
+            frames.splice(idx, 1);
+          } else {
+            destroyDashboard(div.dataset.frameId);
+          }
           area.removeChild(div);
           updateFrameIndices();
           saveFrames();
@@ -614,6 +1274,7 @@
         });
 
         renderSheet(sheetDiv, parseInt(div.dataset.index, 10));
+        renderDashboard(dashboardDiv, parseInt(div.dataset.index, 10));
 
         area.appendChild(div);
 
@@ -728,6 +1389,7 @@
                 evaluateSheet(sheet);
                 renderSheet(container, index);
                 saveFrames();
+                refreshDashboard(index);
               });
             })(r, c, td);
             tr.appendChild(td);
@@ -748,6 +1410,7 @@
         var div = document.querySelector('.frame[data-index="' + index + '"] .spreadsheet');
         renderSheet(div, index);
         saveFrames();
+        refreshDashboard(index);
       }
 
       function removeRow(index) {
@@ -759,6 +1422,7 @@
           var div = document.querySelector('.frame[data-index="' + index + '"] .spreadsheet');
           renderSheet(div, index);
           saveFrames();
+          refreshDashboard(index);
         }
       }
 
@@ -772,6 +1436,7 @@
         var div = document.querySelector('.frame[data-index="' + index + '"] .spreadsheet');
         renderSheet(div, index);
         saveFrames();
+        refreshDashboard(index);
       }
 
       function removeColumn(index) {
@@ -785,12 +1450,16 @@
           var div = document.querySelector('.frame[data-index="' + index + '"] .spreadsheet');
           renderSheet(div, index);
           saveFrames();
+          refreshDashboard(index);
         }
       }
 
       function updateFrameIndices() {
         var children = document.querySelectorAll('.viewing-area .frame');
-        children.forEach(function(c, i) { c.dataset.index = i; });
+        children.forEach(function(c, i) {
+          c.dataset.index = i;
+          if (frames[i]) c.dataset.frameId = frames[i].id;
+        });
       }
 
       function enableDrag(el) {
@@ -802,7 +1471,8 @@
             e.target.classList.contains('resizer') ||
             e.target.classList.contains('frame-title') ||
             e.target.closest('.spreadsheet') ||
-            e.target.classList.contains('sheet-btn')
+            e.target.classList.contains('sheet-btn') ||
+            e.target.closest('.dashboard')
           )
             return;
           e.preventDefault();


### PR DESCRIPTION
## Summary
- add per-frame dashboard toggle so users can show or hide charts as needed
- expose sheet sizing options from the dashboard to expand or contract the data grid
- normalize stored dashboard metadata and reuse a shared layout helper to keep the frame proportions in sync

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68de58b9460c832eba3fbeb3ea21407e