### PR TITLE
Fix upload dropdown layering so options stay visible

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
         border-radius: var(--radius-lg);
         background: var(--surface);
         box-shadow: var(--shadow-soft);
-        overflow: hidden;
+        overflow: visible;
       }
 
       .header::after {
@@ -66,6 +66,7 @@
         background: radial-gradient(circle, rgba(var(--brand-primary-rgb), 0.18) 0%, rgba(var(--brand-primary-rgb), 0) 70%);
         transform: rotate(-12deg);
         pointer-events: none;
+        border-radius: inherit;
       }
 
       .logo {
@@ -199,7 +200,7 @@
         border: 1px solid var(--border-soft);
         box-shadow: 0 22px 40px rgba(15, 23, 42, 0.18);
         overflow: hidden;
-        z-index: 2000;
+        z-index: 3000;
       }
 
       .upload-option {


### PR DESCRIPTION
## Summary
- allow the header container to expose overflowing content so the upload menu is not clipped
- ensure the upload panel stays on top of surrounding UI elements with an increased z-index

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68e07d89c80c832e864f33b2024239de