### PR TITLE
Adjust header weather layout and narrow title card

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,8 +101,9 @@
         display: flex;
         flex-direction: column;
         gap: 8px;
-        flex: 1 1 320px;
-        min-width: 260px;
+        flex: 0 1 340px;
+        min-width: 240px;
+        max-width: 420px;
       }
 
       #header-title {
@@ -128,17 +129,37 @@
         font-weight: 500;
       }
 
+      .weather .datetime {
+        flex: 1 1 auto;
+        gap: 10px;
+        color: rgba(15, 23, 42, 0.72);
+        font-weight: 600;
+        letter-spacing: 0.01em;
+      }
+
+      .weather .datetime .time {
+        font-variant-numeric: tabular-nums;
+      }
+
       .weather {
-        display: inline-flex;
+        display: flex;
         align-items: center;
-        gap: 8px;
-        padding: 8px 14px;
+        justify-content: space-between;
+        gap: 16px;
+        padding: 10px 18px;
         background: linear-gradient(135deg, rgba(255, 255, 255, 0.85), rgba(var(--brand-secondary-rgb), 0.2));
         border-radius: 999px;
         border: 1px solid rgba(var(--brand-primary-rgb), 0.2);
-        font-weight: 600;
         color: var(--brand-dark);
         box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7), 0 12px 22px -18px rgba(var(--brand-primary-rgb), 0.5);
+        flex-wrap: wrap;
+      }
+
+      .weather-current {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        font-weight: 600;
       }
 
       .weather span {
@@ -868,6 +889,16 @@
 
         .header {
           padding: 20px;
+        }
+
+        .weather {
+          width: 100%;
+          justify-content: center;
+          gap: 12px;
+        }
+
+        .weather .datetime {
+          justify-content: center;
         }
 
         .header-controls {
@@ -2300,11 +2331,13 @@
         </div>
         <div class="header-title">
           <h1 id="header-title" contenteditable="true">Route Operations Dashboard</h1>
-          <div id="datetime" class="datetime"></div>
           <div id="weather" class="weather">
-            <span id="weather-icon"></span>
-            <span id="weather-temp"></span>
-            <span id="weather-condition"></span>
+            <div id="datetime" class="datetime"></div>
+            <div class="weather-current" aria-live="polite">
+              <span id="weather-icon"></span>
+              <span id="weather-temp"></span>
+              <span id="weather-condition"></span>
+            </div>
           </div>
         </div>
         <div class="header-controls">


### PR DESCRIPTION
## Summary
- Move the live date/time display inside the weather pill so the weather details sit to the right and the header reads as one grouped status area
- Tighten the Route Operations title column and update responsive rules to free space for the rest of the header controls across breakpoints

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68e119e5f118832ea35d478543a5d688